### PR TITLE
set debug level to 2 for GPU tests

### DIFF
--- a/scripts/test-gpu-tests.sh
+++ b/scripts/test-gpu-tests.sh
@@ -16,4 +16,4 @@ export PATH="/groups/esm/common/julia-1.3:$PATH"
 
 module load cuda/10.0 openmpi/4.0.1_cuda-10.0
 
-julia --color=no --project test/runtests_gpu.jl
+julia -g2 --color=no --project test/runtests_gpu.jl

--- a/scripts/test-gpu.sh
+++ b/scripts/test-gpu.sh
@@ -16,4 +16,4 @@ export PATH="/groups/esm/common/julia-1.3:$PATH"
 
 module load cuda/10.0 openmpi/4.0.1_cuda-10.0
 
-mpiexec julia --color=no --project "$@"
+mpiexec julia -g2 --color=no --project "$@"


### PR DESCRIPTION
To actually get useful information on kernel failures
the only downside should be that the test run a bit more
slowly. Alternativly we could grep the stdout of the test
and resubmit with `-g2` set when we get a kernel failure.