### PR TITLE
Load NetCDF module (and HDF5 dependency)

### DIFF
--- a/scripts/perf-cpu-init.sh
+++ b/scripts/perf-cpu-init.sh
@@ -13,6 +13,6 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/cpu"
 export OPENBLAS_NUM_THREADS=1
 export PATH="/groups/esm/common/julia-1.3:$PATH"
 
-module load openmpi/4.0.1
+module load openmpi/4.0.1 hdf5/1.10.1 netcdf-c/4.6.1
 
 julia --color=no --project -e 'using Pkg; pkg"instantiate"; pkg"build"; pkg"precompile"'

--- a/scripts/perf-gpu-init.sh
+++ b/scripts/perf-gpu-init.sh
@@ -14,6 +14,6 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/gpu"
 export OPENBLAS_NUM_THREADS=1
 export PATH="/groups/esm/common/julia-1.3:$PATH"
 
-module load cuda/10.0 openmpi/4.0.1_cuda-10.0
+module load cuda/10.0 openmpi/4.0.1_cuda-10.0 hdf5/1.10.1 netcdf-c/4.6.1
 
 julia --color=no --project -e 'using Pkg; pkg"instantiate"; pkg"build"; pkg"precompile"'

--- a/scripts/test-cpu-init.sh
+++ b/scripts/test-cpu-init.sh
@@ -15,6 +15,6 @@ export UCX_WARN_UNUSED_ENV_VARS=n
 export CLIMA_GPU=false
 export PATH="/groups/esm/common/julia-1.3:$PATH"
 
-module load openmpi/4.0.1
+module load openmpi/4.0.1 hdf5/1.10.1 netcdf-c/4.6.1
 
 julia --color=no --project -e 'using Pkg; pkg"instantiate"; pkg"build"; pkg"precompile"'

--- a/scripts/test-gpu-init.sh
+++ b/scripts/test-gpu-init.sh
@@ -14,6 +14,6 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/gpu"
 export OPENBLAS_NUM_THREADS=1
 export PATH="/groups/esm/common/julia-1.3:$PATH"
 
-module load cuda/10.0 openmpi/4.0.1_cuda-10.0
+module load cuda/10.0 openmpi/4.0.1_cuda-10.0 hdf5/1.10.1 netcdf-c/4.6.1
 
 julia --color=no --project -e 'using Pkg; pkg"instantiate"; pkg"build"; pkg"precompile"'


### PR DESCRIPTION
Possible fix for failures seen in https://github.com/climate-machine/CLIMA/pull/732 (if some nodes don't have `libnetcdf.so` in `/usr/lib64`).