### PR TITLE
adding /usr/sbin to all paths

### DIFF
--- a/scripts/perf-cleanup.sh
+++ b/scripts/perf-cleanup.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 set -x #echo on
 
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 julia --project finalize-perf.jl
 

--- a/scripts/perf-cpu-init.sh
+++ b/scripts/perf-cpu-init.sh
@@ -11,7 +11,7 @@ cd ${CI_SRCDIR}
 
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/cpu"
 export OPENBLAS_NUM_THREADS=1
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load openmpi/4.0.1 hdf5/1.10.1 netcdf-c/4.6.1
 

--- a/scripts/perf-cpu.sh
+++ b/scripts/perf-cpu.sh
@@ -13,7 +13,7 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/cpu"
 export OPENBLAS_NUM_THREADS=1
 export UCX_WARN_UNUSED_ENV_VARS=n
 export CLIMA_GPU=false
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load openmpi/4.0.1
 

--- a/scripts/perf-gpu-init.sh
+++ b/scripts/perf-gpu-init.sh
@@ -12,7 +12,7 @@ cd ${CI_SRCDIR}
 
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/gpu"
 export OPENBLAS_NUM_THREADS=1
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load cuda/10.0 openmpi/4.0.1_cuda-10.0 hdf5/1.10.1 netcdf-c/4.6.1
 

--- a/scripts/perf-gpu.sh
+++ b/scripts/perf-gpu.sh
@@ -12,7 +12,7 @@ cd ${CI_SRCDIR}
 
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/gpu"
 export OPENBLAS_NUM_THREADS=1
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load cuda/10.0 openmpi/4.0.1_cuda-10.0
 

--- a/scripts/test-cleanup.sh
+++ b/scripts/test-cleanup.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 set -x #echo on
 
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin/:$PATH"
 
 julia --project finalize-test.jl
 

--- a/scripts/test-cpu-init.sh
+++ b/scripts/test-cpu-init.sh
@@ -13,7 +13,7 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/cpu"
 export OPENBLAS_NUM_THREADS=1
 export UCX_WARN_UNUSED_ENV_VARS=n
 export CLIMA_GPU=false
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load openmpi/4.0.1 hdf5/1.10.1 netcdf-c/4.6.1
 

--- a/scripts/test-cpu-tests.sh
+++ b/scripts/test-cpu-tests.sh
@@ -13,7 +13,7 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/cpu"
 export OPENBLAS_NUM_THREADS=1
 export UCX_WARN_UNUSED_ENV_VARS=n
 export CLIMA_GPU=false
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load openmpi/4.0.1
 

--- a/scripts/test-cpu.sh
+++ b/scripts/test-cpu.sh
@@ -13,7 +13,7 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/cpu"
 export OPENBLAS_NUM_THREADS=1
 export UCX_WARN_UNUSED_ENV_VARS=n
 export CLIMA_GPU=false
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load openmpi/4.0.1
 

--- a/scripts/test-gpu-init.sh
+++ b/scripts/test-gpu-init.sh
@@ -12,7 +12,7 @@ cd ${CI_SRCDIR}
 
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/gpu"
 export OPENBLAS_NUM_THREADS=1
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load cuda/10.0 openmpi/4.0.1_cuda-10.0 hdf5/1.10.1 netcdf-c/4.6.1
 

--- a/scripts/test-gpu-tests.sh
+++ b/scripts/test-gpu-tests.sh
@@ -12,7 +12,7 @@ cd ${CI_SRCDIR}
 
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/gpu"
 export OPENBLAS_NUM_THREADS=1
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load cuda/10.0 openmpi/4.0.1_cuda-10.0
 

--- a/scripts/test-gpu.sh
+++ b/scripts/test-gpu.sh
@@ -12,7 +12,7 @@ cd ${CI_SRCDIR}
 
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/gpu"
 export OPENBLAS_NUM_THREADS=1
-export PATH="/groups/esm/common/julia-1.3:$PATH"
+export PATH="/groups/esm/common/julia-1.3:/usr/sbin:$PATH"
 
 module load cuda/10.0 openmpi/4.0.1_cuda-10.0
 


### PR DESCRIPTION
This should be a fix for Issue #14. By adding `usr/sbin` to all paths, `ldconfig -p` should be available, which is necessary for the build of NCDatasets for CLIMA