### PR TITLE
Boost times for `test/runtests*` again.

### DIFF
--- a/scripts/test-cpu-init.sh
+++ b/scripts/test-cpu-init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=1:00:00     # walltime
+#SBATCH --time=0:30:00     # walltime
 #SBATCH --nodes=1          # number of nodes
 #SBATCH --mem-per-cpu=4G   # memory per CPU core
 

--- a/scripts/test-cpu-tests.sh
+++ b/scripts/test-cpu-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-#SBATCH --time=1:30:00     # walltime
+#SBATCH --time=2:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
+#SBATCH --ntasks=4         # number of cores
 #SBATCH --mem-per-cpu=4G   # memory per CPU core
 
 set -euo pipefail
@@ -10,6 +11,7 @@ set -x #echo on
 cd ${CI_SRCDIR}
 
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/cpu"
+export JULIA_NUM_THREADS=4
 export OPENBLAS_NUM_THREADS=1
 export UCX_WARN_UNUSED_ENV_VARS=n
 export CLIMA_GPU=false

--- a/scripts/test-gpu-init.sh
+++ b/scripts/test-gpu-init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=1:00:00     # walltime
+#SBATCH --time=0:30:00     # walltime
 #SBATCH --nodes=1          # number of nodes
 #SBATCH --mem-per-cpu=4G   # memory per CPU core
 #SBATCH --gres=gpu:1

--- a/scripts/test-gpu-tests.sh
+++ b/scripts/test-gpu-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=1:00:00     # walltime
+#SBATCH --time=2:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
 #SBATCH --mem-per-cpu=4G   # memory per CPU core
 #SBATCH --gres=gpu:1


### PR DESCRIPTION
Another boost, for `KernelAbstractions` testing. I adjusted the `init` timings down, since they complete in <5 minutes from what I'm seeing.