### PR TITLE
Bump memory allocation

### DIFF
--- a/scripts/perf-cpu-init.sh
+++ b/scripts/perf-cpu-init.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=1:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 
 set -euo pipefail
 set -x #echo on

--- a/scripts/perf-cpu.sh
+++ b/scripts/perf-cpu.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=1:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 
 set -euo pipefail
 set -x #echo on

--- a/scripts/perf-gpu-init.sh
+++ b/scripts/perf-gpu-init.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=1:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 #SBATCH --gres=gpu:1
 
 set -euo pipefail

--- a/scripts/perf-gpu.sh
+++ b/scripts/perf-gpu.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=0:45:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 #SBATCH --gres=gpu:4
 
 set -euo pipefail

--- a/scripts/test-cpu-init.sh
+++ b/scripts/test-cpu-init.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=0:30:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 
 set -euo pipefail
 set -x #echo on

--- a/scripts/test-cpu-tests.sh
+++ b/scripts/test-cpu-tests.sh
@@ -3,7 +3,7 @@
 #SBATCH --time=3:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
 #SBATCH --ntasks=4         # number of cores
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 
 set -euo pipefail
 set -x #echo on

--- a/scripts/test-cpu.sh
+++ b/scripts/test-cpu.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=1:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 
 set -euo pipefail
 set -x #echo on

--- a/scripts/test-gpu-init.sh
+++ b/scripts/test-gpu-init.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=0:30:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 #SBATCH --gres=gpu:1
 
 set -euo pipefail

--- a/scripts/test-gpu-tests.sh
+++ b/scripts/test-gpu-tests.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=2:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 #SBATCH --gres=gpu:1
 
 set -euo pipefail

--- a/scripts/test-gpu.sh
+++ b/scripts/test-gpu.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --time=01:00:00     # walltime
 #SBATCH --nodes=1          # number of nodes
-#SBATCH --mem-per-cpu=4G   # memory per CPU core
+#SBATCH --mem-per-cpu=5G   # memory per CPU core
 #SBATCH --gres=gpu:1
 
 set -euo pipefail


### PR DESCRIPTION
There seems to be some failures in CI lately due to `OutOfMemoryError()`'s. For example:

- https://gist.github.com/climabot/9c8ffbda161fcf84f96305af1b901082
- https://gist.github.com/climabot/133065bab3e19a3d522f2ecaebbd7504

So this bumps the mem allocation
